### PR TITLE
Fix SystemUI crash loop caused by in-place privacy list mutation on HyperOS 4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,8 +10,8 @@ android {
         applicationId = "com.dorian15.greendothide"
         minSdk = 24
         targetSdk = 35
-        versionCode = 4
-        versionName = "1.4"
+        versionCode = 5
+        versionName = "1.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/dorian15/greendothide/xposed/Hook.java
+++ b/app/src/main/java/com/dorian15/greendothide/xposed/Hook.java
@@ -76,6 +76,7 @@ public class Hook implements IXposedHookLoadPackage {
             XposedBridge.log("[GreenDotHide] Hooked into: " + cls + "." + method);
         } catch (Throwable e) {
             XposedBridge.log("[GreenDotHide] Ignoring hook: " + cls + "." + method);
+            XposedBridge.log(e);
         }
     }
 
@@ -120,18 +121,22 @@ public class Hook implements IXposedHookLoadPackage {
             @Override
             protected void beforeHookedMethod(MethodHookParam param) {
                 Bundle bundleArg = (Bundle) param.args[2];
+                if (bundleArg == null)
+                    return;
                 int[] dotType = bundleArg.getIntArray("key_prompt_type");
                 if (dotType == null || dotType.length == 0)
                     return;
                 boolean[] hide = {hideCamera, hideMic, hideLocation, hideMedia};
-                boolean isEmpty = true;
-                for (int i = 0; i < Math.min(dotType.length, hide.length); i++) {
+                for (int i = 0; i < Math.min(dotType.length, hide.length); i++)
                     if (hide[i])
                         dotType[i] = 0;
-                    if (dotType[i] != 0)
-                        isEmpty = false;
-                }
                 bundleArg.putIntArray("key_prompt_type", dotType);
+                boolean isEmpty = true;
+                for (int v : dotType)
+                    if (v != 0) {
+                        isEmpty = false;
+                        break;
+                    }
                 if (isEmpty)
                     param.setResult(null);
             }

--- a/app/src/main/java/com/dorian15/greendothide/xposed/Hook.java
+++ b/app/src/main/java/com/dorian15/greendothide/xposed/Hook.java
@@ -1,8 +1,9 @@
 package com.dorian15.greendothide.xposed;
 
 import android.os.Bundle;
-import java.util.List;
 
+import java.util.ArrayList;
+import java.util.List;
 
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodHook;
@@ -12,207 +13,174 @@ import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.XposedHelpers;
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
-public class Hook implements IXposedHookLoadPackage{
+public class Hook implements IXposedHookLoadPackage {
 
-    private boolean hideLocation=true;
-    private boolean hideMic=true;
-    private boolean hideCamera=true;
-    private boolean hideMedia=true;
+    private static final String MIUI_PRIVACY_CONTROLLER = "com.android.systemui.statusbar.privacy.MiuiPrivacyControllerImpl";
+    private static final String PRIVACY_ITEM_CONTROLLER = "com.android.systemui.privacy.PrivacyItemController";
+    private static final String PRIVACY_CONFIG = "com.android.systemui.privacy.PrivacyConfig";
 
-    private void updatePrivacyList(Object privacyItemController){
-        List<?> privacyList = (List<?>) XposedHelpers.getObjectField(privacyItemController, "privacyList");
-        privacyList.removeIf(privacyItem -> {
-            String privacyType = XposedHelpers.getObjectField(privacyItem, "privacyType").toString();
-            return (privacyType.equals("TYPE_MICROPHONE") && hideMic) ||
-                    (privacyType.equals("TYPE_CAMERA") && hideCamera) ||
-                    (privacyType.equals("TYPE_LOCATION") && hideLocation) ||
-                    (privacyType.equals("TYPE_MEDIA_PROJECTION") && hideMedia);
-        });
-        XposedHelpers.setObjectField(privacyItemController,"privacyList",privacyList);
+    private boolean hideLocation = true;
+    private boolean hideMic = true;
+    private boolean hideCamera = true;
+    private boolean hideMedia = true;
+
+    private boolean shouldHide(String privacyType) {
+        return (privacyType.equals("TYPE_MICROPHONE") && hideMic)
+                || (privacyType.equals("TYPE_CAMERA") && hideCamera)
+                || (privacyType.equals("TYPE_LOCATION") && hideLocation)
+                || (privacyType.equals("TYPE_MEDIA_PROJECTION") && hideMedia);
     }
+
+    /**
+     * Builds a NEW list without hidden items. The input list is never mutated:
+     * SystemUI components keep references to the same instance, and in-place
+     * removal corrupts their state (root cause of SystemUI crashes).
+     */
+    private List<Object> filterPrivacyList(List<?> list) {
+        List<Object> filtered = new ArrayList<>(list.size());
+        for (Object item : list) {
+            if (item == null)
+                continue;
+            try {
+                Object type = XposedHelpers.getObjectField(item, "privacyType");
+                if (type != null && shouldHide(type.toString()))
+                    continue;
+            } catch (Throwable t) {
+                XposedBridge.log("[GreenDotHide] " + t);
+            }
+            filtered.add(item);
+        }
+        return filtered;
+    }
+
+    /** Swaps the controller's cached privacyList for a filtered copy; never mutates the original. */
+    private void filterControllerList(Object controller) {
+        try {
+            List<?> current = (List<?>) XposedHelpers.getObjectField(controller, "privacyList");
+            if (current == null)
+                return;
+            List<Object> filtered = filterPrivacyList(current);
+            if (filtered.size() != current.size())
+                XposedHelpers.setObjectField(controller, "privacyList", filtered);
+        } catch (Throwable t) {
+            XposedBridge.log("[GreenDotHide] " + t);
+        }
+    }
+
+    private void safeHook(LoadPackageParam lpparam, String cls, String method, XC_MethodHook cb, Object... paramTypes) {
+        Object[] args = new Object[paramTypes.length + 1];
+        System.arraycopy(paramTypes, 0, args, 0, paramTypes.length);
+        args[paramTypes.length] = cb;
+        try {
+            XposedHelpers.findAndHookMethod(cls, lpparam.classLoader, method, args);
+            XposedBridge.log("[GreenDotHide] Hooked into: " + cls + "." + method);
+        } catch (Throwable e) {
+            XposedBridge.log("[GreenDotHide] Ignoring hook: " + cls + "." + method);
+        }
+    }
+
     @Override
     public void handleLoadPackage(final LoadPackageParam lpparam) throws Throwable {
 
         // self hook to show module as enabled
-        if(lpparam.packageName.equals("com.dorian15.greendothide"))
+        if (lpparam.packageName.equals("com.dorian15.greendothide"))
             XposedHelpers.findAndHookMethod("com.dorian15.greendothide.MainActivity", lpparam.classLoader, "isModuleEnabled",
                     XC_MethodReplacement.returnConstant(true));
 
         if (!lpparam.packageName.equals("com.android.systemui"))
             return;
 
-        XSharedPreferences sharedPrefs = new XSharedPreferences("com.dorian15.greendothide","prefs");
-        sharedPrefs.reload();
-        hideLocation = sharedPrefs.getBoolean("disable_location_indicator",true);
-        hideMic = sharedPrefs.getBoolean("disable_microphone_indicator",true);
-        hideCamera = sharedPrefs.getBoolean("disable_camera_indicator",true);
-        hideMedia = sharedPrefs.getBoolean("disable_media_projection_indicator",true);
+        XSharedPreferences prefs = new XSharedPreferences("com.dorian15.greendothide", "prefs");
+        prefs.reload();
+        hideLocation = prefs.getBoolean("disable_location_indicator", true);
+        hideMic = prefs.getBoolean("disable_microphone_indicator", true);
+        hideCamera = prefs.getBoolean("disable_camera_indicator", true);
+        hideMedia = prefs.getBoolean("disable_media_projection_indicator", true);
 
-        // HyperOS/MIUI
-        String className = "com.android.systemui.statusbar.privacy.MiuiPrivacyControllerImpl";
-        String methodName = "setStatus";
-        try{
-            XposedHelpers.findAndHookMethod(
-                    className,
-                    lpparam.classLoader,
-                    methodName,
-                    int.class,
-                    String.class,
-                    android.os.Bundle.class,
-                    new XC_MethodHook() {
-                        @Override
-                        protected void beforeHookedMethod(MethodHookParam param) {
-                            Bundle bundleArg = (Bundle)param.args[2];
-                            int[] dotType = bundleArg.getIntArray("key_prompt_type");
+        // MIUI/HyperOS: entry point of privacy item updates; hand MIUI a filtered
+        // copy instead of the original list, and skip updates left fully hidden.
+        safeHook(lpparam, MIUI_PRIVACY_CONTROLLER, "onPrivacyItemsChanged", new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) {
+                List<?> incoming = (List<?>) param.args[0];
+                if (incoming == null)
+                    return;
+                List<Object> filtered = filterPrivacyList(incoming);
+                if (filtered.isEmpty())
+                    param.setResult(null);
+                else
+                    param.args[0] = filtered;
+            }
+        }, List.class);
 
-                            if(hideCamera)
-                                dotType[0]=0;
-                            if(hideMic)
-                                dotType[1]=0;
-                            if(hideLocation)
-                                dotType[2]=0;
-                            if(hideMedia)
-                                dotType[3]=0;
+        // HyperOS/MIUI status path; zero out hidden prompt types and skip the
+        // original when nothing remains, so the pre-rendered dot RemoteViews are
+        // never applied to the status bar.
+        safeHook(lpparam, MIUI_PRIVACY_CONTROLLER, "setStatus", new XC_MethodHook() {
+            @Override
+            protected void beforeHookedMethod(MethodHookParam param) {
+                Bundle bundleArg = (Bundle) param.args[2];
+                int[] dotType = bundleArg.getIntArray("key_prompt_type");
+                if (dotType == null || dotType.length == 0)
+                    return;
+                boolean[] hide = {hideCamera, hideMic, hideLocation, hideMedia};
+                boolean isEmpty = true;
+                for (int i = 0; i < Math.min(dotType.length, hide.length); i++) {
+                    if (hide[i])
+                        dotType[i] = 0;
+                    if (dotType[i] != 0)
+                        isEmpty = false;
+                }
+                bundleArg.putIntArray("key_prompt_type", dotType);
+                if (isEmpty)
+                    param.setResult(null);
+            }
+        }, int.class, String.class, Bundle.class);
 
-                            bundleArg.putIntArray("key_prompt_type",dotType);
-
-                            boolean isEmpty=true;
-                            for(int i=0; i<dotType.length;i++){
-                                if(dotType[i]==1){
-                                    isEmpty=false;
-                                    break;
-                                }
-                            }
-
-                            if(isEmpty)
-                                param.setResult(null);
-                        }
-                    }
-            );
-            XposedBridge.log("[GreenDotHide] Hooked into: "+className+"."+methodName);
-        }catch(Throwable e){
-            XposedBridge.log("[GreenDotHide] Ignoring hook: "+className+"."+methodName);
-        }
-
-        // AOSP based SystemUI
-        className = "com.android.systemui.privacy.PrivacyConfig";
-        methodName = "isLocationEnabled";
-        try{
-            XposedHelpers.findAndHookMethod(
-                    className,
-                    lpparam.classLoader,
-                    methodName,
-                    new XC_MethodHook() {
-                        @Override
-                        protected void beforeHookedMethod(MethodHookParam param) {
-                            if(hideLocation)
-                                param.setResult(false);
-                        }
-                    }
-            );
-            XposedBridge.log("[GreenDotHide] Hooked into: "+className+"."+methodName);
-        }catch(Throwable e){
-            XposedBridge.log("[GreenDotHide] Ignoring hook: "+className+"."+methodName);
-        }
-
-        methodName = "isMicCameraEnabled";
-        try{
-            XposedHelpers.findAndHookMethod(
-                    className,
-                    lpparam.classLoader,
-                    methodName,
-                    new XC_MethodHook() {
-                        @Override
-                        protected void beforeHookedMethod(MethodHookParam param) {
-                            if (hideMic && hideCamera)
-                                param.setResult(false);
-                        }
-                    }
-            );
-            XposedBridge.log("[GreenDotHide] Hooked into: "+className+"."+methodName);
-        }catch(Throwable e){
-            XposedBridge.log("[GreenDotHide] Ignoring hook: "+className+"."+methodName);
-        }
-
-        methodName = "isMediaProjectionEnabled";
-        try{
-            XposedHelpers.findAndHookMethod(
-                    className,
-                    lpparam.classLoader,
-                    methodName,
-                    new XC_MethodHook() {
-                        @Override
-                        protected void beforeHookedMethod(MethodHookParam param) {
-                            if(hideMedia)
-                                param.setResult(false);
-                        }
-                    }
-            );
-            XposedBridge.log("[GreenDotHide] Hooked into: "+className+"."+methodName);
-        }catch(Throwable e){
-            XposedBridge.log("[GreenDotHide] Ignoring hook: "+className+"."+methodName);
+        // AOSP based SystemUI: kill indicators at the config level.
+        Object[][] configSwitches = {
+                {"isLocationEnabled", hideLocation},
+                {"isMicCameraEnabled", hideMic && hideCamera},
+                {"isMediaProjectionEnabled", hideMedia},
+        };
+        for (Object[] sw : configSwitches) {
+            boolean enabled = (Boolean) sw[1];
+            safeHook(lpparam, PRIVACY_CONFIG, (String) sw[0], new XC_MethodHook() {
+                @Override
+                protected void beforeHookedMethod(MethodHookParam param) {
+                    if (enabled)
+                        param.setResult(false);
+                }
+            });
         }
 
         // Android 12-13
-        className = "com.android.systemui.privacy.PrivacyItemController";
-        methodName = "updatePrivacyList";
-        try{
-            XposedHelpers.findAndHookMethod(
-                    className,
-                    lpparam.classLoader,
-                    methodName,
-                    new XC_MethodHook() {
-                        @Override
-                        protected void afterHookedMethod(MethodHookParam param) {
-                            updatePrivacyList(param.thisObject);
-                        }
-                    }
-            );
-            XposedBridge.log("[GreenDotHide] Hooked into: "+className+"."+methodName);
-        }catch(Throwable e){
-            XposedBridge.log("[GreenDotHide] Ignoring hook: "+className+"."+methodName);
-        }
+        safeHook(lpparam, PRIVACY_ITEM_CONTROLLER, "updatePrivacyList", new XC_MethodHook() {
+            @Override
+            protected void afterHookedMethod(MethodHookParam param) {
+                filterControllerList(param.thisObject);
+            }
+        });
 
         // Android 15-16
-        className = "com.android.systemui.privacy.PrivacyItemController";
-        methodName = "getPrivacyList$frameworks__base__packages__SystemUI__android_common__SystemUI_core";
-
-        try{
-            XposedHelpers.findAndHookMethod(
-                    className,
-                    lpparam.classLoader,
-                    methodName,
-                    new XC_MethodHook() {
-                        @Override
-                        protected void beforeHookedMethod(MethodHookParam param) {
-                            updatePrivacyList(param.thisObject);
-                        }
+        safeHook(lpparam, PRIVACY_ITEM_CONTROLLER,
+                "getPrivacyList$frameworks__base__packages__SystemUI__android_common__SystemUI_core",
+                new XC_MethodHook() {
+                    @Override
+                    protected void afterHookedMethod(MethodHookParam param) {
+                        Object result = param.getResult();
+                        if (result instanceof List)
+                            param.setResult(filterPrivacyList((List<?>) result));
                     }
-            );
-            XposedBridge.log("[GreenDotHide] Hooked into: "+className+"."+methodName);
-        }catch(Throwable e){
-            XposedBridge.log("[GreenDotHide] Ignoring hook: "+className+"."+methodName);
-        }
+                });
 
-        // Android 14
-        className = "com.android.systemui.privacy.PrivacyItemController$updateListAndNotifyChanges$1";
-        methodName = "run";
-        try{
-            XposedHelpers.findAndHookMethod(
-                    className,
-                    lpparam.classLoader,
-                    methodName,
-                    new XC_MethodHook() {
-                        @Override
-                        protected void afterHookedMethod(MethodHookParam param) {
-                            Object privacyItemController = XposedHelpers.getObjectField(param.thisObject, "this$0");
-                            updatePrivacyList(privacyItemController);
-                        }
-                    }
-            );
-            XposedBridge.log("[GreenDotHide] Hooked into: "+className+"."+methodName);
-        }catch(Throwable e){
-            XposedBridge.log("[GreenDotHide] Ignoring hook: "+className+"."+methodName);
-        }
+        // Android 14: swap the cached list AFTER the original runnable completes;
+        // the shared list object is never modified.
+        safeHook(lpparam, PRIVACY_ITEM_CONTROLLER + "$updateListAndNotifyChanges$1", "run", new XC_MethodHook() {
+            @Override
+            protected void afterHookedMethod(MethodHookParam param) {
+                filterControllerList(XposedHelpers.getObjectField(param.thisObject, "this$0"));
+            }
+        });
     }
 }


### PR DESCRIPTION
## Problem

On HyperOS 4 (Android 17 base), enabling the module caused `com.android.systemui` to crash repeatedly (~15+ times/day). All 56 recorded crashes were in the privacy indicator code path, with three signatures:

```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0          (39x)
java.lang.NullPointerException: ... PrivacyItem.privacyType' on a null object
    reference in MiuiPrivacyControllerImpl.onPrivacyItemsChanged                 (12x)
java.lang.NullPointerException: ... PrivacyItem.toString()' on a null object
    reference                                                                    (5x)
```

### Root cause

`updatePrivacyList()` mutated the shared `privacyList` **in place** via `removeIf()` immediately after the same list instance had already been handed to `MiuiPrivacyControllerImpl.onPrivacyItemsChanged(list)`. MIUI's implementation keeps processing that reference and trips over the emptied/torn list. Additionally, the `setStatus(int, String, Bundle)` hook indexed `dotType[0..3]` unguarded, which throws on ROMs where the array is absent or shorter than expected.

A related regression surfaced after fixing the crash: zeroing `key_prompt_type` alone is not enough on HyperOS 4, because the bundle carries pre-rendered dot RemoteViews (`key_status_bar_home_state` / `key_status_bar_mini_state`). Skipping `setStatus` entirely via `setResult(null)` when all tracked types are hidden is what actually suppresses the dot.

## Fix

- Never mutate shared lists: filter into a new list everywhere. A new consumer-side hook on `MiuiPrivacyControllerImpl.onPrivacyItemsChanged(List)` replaces the argument with a filtered copy (also dropping null entries) and skips updates left fully empty.
- Guard the `setStatus` prompt-type array access (null/length checks, bounds-safe loop) and skip the original method when everything is hidden.
- Reflection is confined to guarded entry points so exceptions can never propagate into SystemUI.
- Refactor: collapse 8 repeated hook scaffolds into one `safeHook` helper (-167 lines net).

## Tested on Xiaomi popsicle, HyperOS 4.0.0.20.XPBCNXM (Android 17)

- 4x camera cold-start stress: SystemUI process stable; 0 new FATAL entries in dropbox/logcat (previously crashed every ~30 min).
- Status-bar pixel scan during active camera use: privacy dot suppressed.
- Hook install logs verified identical across refactors.
